### PR TITLE
feat: add automatic Homebrew and Scoop package manager updates

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,9 +5,9 @@ on:
   release:
     types: [published]
 jobs:
-  publish-pypi:
+  release:
     runs-on: ubuntu-latest
-    name: Publish on PyPI
+    name: Publish Release
     permissions:
       id-token: write  # IMPORTANT: Mandatory for Trusted Publishing (gh-action-pypi-publish)
       contents: write  # IMPORTANT: Mandatory for GitHub Release
@@ -40,3 +40,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.ref_name }} ./dist/* --clobber
+      - name: Trigger Homebrew Formula Update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          repository: python-ankara-toplulugu/homebrew-tap
+          event-type: update-formula
+          client-payload: '{"formula": "${{ github.event.repository.name }}", "version": "${{ github.event.release.tag_name }}"}'
+      - name: Trigger Scoop Manifest Update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+          repository: python-ankara-toplulugu/scoop-bucket
+          event-type: update-manifest
+          client-payload: '{"package": "${{ github.event.repository.name }}", "version": "${{ github.event.release.tag_name }}"}'


### PR DESCRIPTION
This PR adds automatic package manager updates to the CD workflow.

When a new release is published, the workflow now triggers updates to both the Homebrew formula and Scoop manifest via repository dispatch events. This eliminates manual update steps and ensures package managers are updated immediately after PyPI publication.

**Required setup:** Add `HOMEBREW_TAP_TOKEN` and `SCOOP_BUCKET_TOKEN` secrets to repository settings.